### PR TITLE
Add luasec so we can hit crowd behind https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.9
 RUN apk update && \
     apk add nginx-mod-http-lua ca-certificates && \
-    apk add --virtual build-deps bash build-base curl lua5.1-dev luarocks5.1 && \
+    apk add --virtual build-deps bash build-base curl lua5.1-dev luarocks5.1 openssl-dev && \
+    /usr/bin/luarocks-5.1 install luasec && \
     /usr/bin/luarocks-5.1 install lua-Spore && \
     mkdir -p /tmp/src && \
     cd /tmp/src && \


### PR DESCRIPTION
Right now, our nginx is returning a 500 when trying to hit crowd via https.

```2019/08/27 18:37:37 [error] 9#9: *321 lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/Spore/Protocols.lua:107: not protocol https```

From https://github.com/knq/nginx-crowd-lua/issues/2, we need to install luasec to resolve this.